### PR TITLE
Update packages

### DIFF
--- a/src/package/codly.typ
+++ b/src/package/codly.typ
@@ -1,4 +1,4 @@
-#import "@preview/codly:0.2.0": *
+#import "@preview/codly:1.2.0": *
 
 #let codly = codly.with(
   // display-icon: false, display-name: false,

--- a/src/package/ctheorems.typ
+++ b/src/package/ctheorems.typ
@@ -1,4 +1,4 @@
-#import "@preview/ctheorems:1.1.2": *
+#import "@preview/ctheorems:1.1.3": *
 
 #let thmrules = thmrules.with(qed-symbol: $square.stroked$)
 


### PR DESCRIPTION
- Update the ctheorems package to 1.1.3
- Update codly to 1.2.0

Fixed alignment and block-breaking issues resulting from breaking changes in Typst 0.12.
